### PR TITLE
Add Rail Delay setting

### DIFF
--- a/custom_components/rainbird/config_flow.py
+++ b/custom_components/rainbird/config_flow.py
@@ -5,24 +5,27 @@ import logging
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.const import CONF_PASSWORD, CONF_HOST, CONF_MONITORED_CONDITIONS, CONF_TRIGGER_TIME, \
+from homeassistant.const import CONF_NAME, CONF_PASSWORD, CONF_HOST, CONF_MONITORED_CONDITIONS, CONF_TRIGGER_TIME, \
     CONF_SCAN_INTERVAL
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowHandler
+from pyrainbird import RainbirdController
 
-from . import DOMAIN, CONF_NUMBER_OF_STATIONS, SENSOR_TYPES
+from .const import DOMAIN, CONF_NUMBER_OF_STATIONS, SENSOR_TYPES, CONF_RETRY_COUNT, CONF_RETRY_DELAY
+from . import get_rainbird_controller
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def show_form(flow: FlowHandler, step: str, first_time: bool, data=None):
+async def show_form(flow: FlowHandler, step: str, first_time: bool, advanced: bool, data=None):
     if data is None:
         data = {}
     dict_ = {}
     if first_time:
-        dict_.update({vol.Required(CONF_HOST, default='rainbird.home'): str})
+        dict_.update({vol.Required(CONF_NAME, default='Rainbird Controller'): str})
     dict_.update({
-        vol.Optional(CONF_PASSWORD, default=data.get(CONF_PASSWORD, None)): str,
+        vol.Required(CONF_HOST, default=data.get(CONF_HOST,'rainbird.home')): str,
+        vol.Required(CONF_PASSWORD, default=data.get(CONF_PASSWORD, None)): str,
         vol.Optional(CONF_NUMBER_OF_STATIONS, default=data.get(CONF_NUMBER_OF_STATIONS, 0)): int,
         vol.Optional(CONF_MONITORED_CONDITIONS,
                      default=data.get(CONF_MONITORED_CONDITIONS, list(SENSOR_TYPES.keys()))): cv.multi_select(
@@ -32,6 +35,11 @@ async def show_form(flow: FlowHandler, step: str, first_time: bool, data=None):
         vol.Optional(CONF_SCAN_INTERVAL,
                      default=data.get(CONF_SCAN_INTERVAL, {"seconds": 20})): cv.positive_time_period_dict
     })
+    if advanced:
+        dict_.update({
+            vol.Optional(CONF_RETRY_COUNT, default=data.get(CONF_RETRY_COUNT, 3)): int,
+            vol.Optional(CONF_RETRY_DELAY, default=data.get(CONF_RETRY_DELAY, 7)): int
+        })
     return flow.async_show_form(
         step_id=step, data_schema=vol.Schema(dict_), description_placeholders={"host": data.get(CONF_HOST, '')}
     )
@@ -53,7 +61,7 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Rainbird."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     def __init__(self):
         """Initialize."""
@@ -65,16 +73,29 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._errors = {}
         if user_input is not None:
             if user_input[CONF_HOST]:
-                await self.async_set_unique_id(user_input[CONF_HOST])
-                self._abort_if_unique_id_configured()
                 time_to_secs(user_input, CONF_TRIGGER_TIME)
                 time_to_secs(user_input, CONF_SCAN_INTERVAL)
-                self._data.update(user_input)
-                # Call next step
-                return self.async_create_entry(title=self._data[CONF_HOST], data=self._data)
+                serial = await self.check_serial(**user_input)
+                if serial:
+                    await self.async_set_unique_id(serial)
+                    self._abort_if_unique_id_configured()
+                    self._data.update(user_input)
+                    # Call next step
+                    return self.async_create_entry(title=self._data[CONF_NAME], data=self._data)
             else:
                 self._errors["base"] = "host"
-        return await show_form(self, "user", True)
+        return await show_form(self, "user", True, self.show_advanced_options)
+
+    async def check_serial(self, **kwargs) -> bool:
+        """Check if login credentials are valid."""
+        client = await self.hass.async_add_executor_job(
+            get_rainbird_controller, kwargs
+        )
+        serial = await self.hass.async_add_executor_job(
+            client.get_serial_number
+        )
+        return serial
+
 
     async def async_step_import(self, user_input):  # pylint: disable=unused-argument
         """Import a config entry.
@@ -118,7 +139,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is None:
             time_to_dict(self._data, CONF_TRIGGER_TIME)
             time_to_dict(self._data, CONF_SCAN_INTERVAL)
-            return await show_form(self, "init", False, self._data)
+            return await show_form(self, "init", False, self.show_advanced_options, self._data)
         else:
             # Update entry
             self._data.update(user_input)

--- a/custom_components/rainbird/const.py
+++ b/custom_components/rainbird/const.py
@@ -1,0 +1,40 @@
+"""Consts for Rain Bird Irrigation system LNK WiFi Module."""
+
+import json
+import os
+
+DOMAIN = "rainbird"
+
+DISPATCHER_UPDATE_ENTITY = DOMAIN + "_{entry_id}_update_{component_key}_{key}"
+DISPATCHER_REMOVE_ENTITY = DOMAIN + "_{entry_id}_remove_{component_key}_{key}"
+DISPATCHER_ON_LIST = DOMAIN + "_{entry_id}_on_list"
+DISPATCHER_ON_DEVICE_UPDATE = DOMAIN + "_{entry_id}_on_device_update"
+DISPATCHER_ON_STATE = DOMAIN + "_{entry_id}_on_state"
+
+MANIFEST = json.load(open("%s/manifest.json" % os.path.dirname(os.path.realpath(__file__))))
+VERSION = MANIFEST["version"]
+DOMAIN = MANIFEST["domain"]
+DEFAULT_NAME = MANIFEST["name"]
+
+PLATFORM_SENSOR = "sensor"
+PLATFORM_BINARY_SENSOR = "binary_sensor"
+CONF_NUMBER_OF_STATIONS = "number_of_stations"
+SENSOR_TYPES = {"rainsensor": ["Rain Sensor", None, "mdi:water"]}
+
+CONF_RETRY_COUNT = "retry_count"
+CONF_RETRY_DELAY = "retry_delay"
+
+RAINBIRD_MODELS = {
+    0x003: ["ESP_RZXe", 0, "ESP-RZXe", False, 0, 6],
+    0x007: ["ESP_ME", 1, "ESP-Me", True, 4, 6],
+    0x006: ["ST8X_WF", 2, "ST8x-WiFi", False, 0, 6],
+    0x005: ["ESP_TM2", 3, "ESP-TM2", True, 3, 4],
+    0x008: ["ST8X_WF2", 4, "ST8x-WiFi2", False, 8, 6],
+    0x009: ["ESP_ME3", 5, "ESP-ME3", True, 4, 6],
+    0x010: ["MOCK_ESP_ME2", 6, "ESP=Me2", True, 4, 6],
+    0x00A: ["ESP_TM2v2", 7, "ESP-TM2", True, 3, 4],
+    0x10A: ["ESP_TM2v3", 8, "ESP-TM2", True, 3, 4],
+    0x099: ["TBOS_BT", 9, "TBOS-BT", True, 3, 8],
+    0x107: ["ESP_MEv2", 10, "ESP-Me", True, 4, 6],
+    0x103: ["ESP_RZXe2", 11, "ESP-RZXe2", False, 8, 6]
+}

--- a/custom_components/rainbird/manifest.json
+++ b/custom_components/rainbird/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "rainbird",
   "name": "Rainbird",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "documentation": "https://www.home-assistant.io/integrations/rainbird",
   "config_flow": true,
   "requirements": [

--- a/custom_components/rainbird/number.py
+++ b/custom_components/rainbird/number.py
@@ -1,0 +1,72 @@
+"""Support for Rain Bird Irrigation system LNK WiFi Module."""
+import logging
+
+import voluptuous as vol
+from homeassistant.components.number import PLATFORM_SCHEMA, NumberEntity
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers.typing import HomeAssistantType
+from pyrainbird import RainbirdController
+
+from . import RuntimeEntryData, DOMAIN, RainbirdEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def add_entities(config_entry, data: RuntimeEntryData, async_add_entities, hass: HomeAssistantType):
+    async_add_entities([RainDelayEntity(hass, data.client, config_entry.data, data)], True)
+    return True
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up Rainbird number entities."""
+    data = hass.data.get(DOMAIN)[config_entry.entry_id]
+    await hass.async_add_executor_job(add_entities, config_entry, data, async_add_entities, hass)
+
+
+class RainBirdNumber(RainbirdEntity, NumberEntity):
+    """Representation of a Rain Bird number."""
+
+    def __init__(self, hass, controller, name, unique_id, device_info, data, icon, attributes=None):
+        """Initialize a Rain Bird Number Device."""
+        super(RainBirdNumber, self).__init__(hass, controller, name, unique_id, device_info, data, icon, attributes)
+
+        self._state = None
+
+    @property
+    def value(self):
+        return self._state
+
+class RainDelayEntity(RainBirdNumber):
+    def __init__(self, hass, controller, device_info, data = None, attributes=None):
+        super().__init__(hass, controller, "Rain Delay", "raindelay", device_info, data, "mdi:clock", attributes)
+
+    @property
+    def icon(self):
+        return 'mdi:timer-outline' if self._state > 0 else 'mdi:timer-off-outline'
+
+    @property
+    def min_value(self):
+        return 0
+
+    @property
+    def max_value(self):
+        return 14
+
+    @property
+    def step(self):
+        return 1
+
+    @property
+    def min_value(self):
+        return 0
+
+    @property
+    def unit_of_measurement(self):
+        return "days"
+
+    def update(self):
+        """Update switch status."""
+        self._state = self._controller.get_rain_delay()
+
+    def set_value(self, value: float):
+        self._controller.set_rain_delay(int(value))

--- a/custom_components/rainbird/switch.py
+++ b/custom_components/rainbird/switch.py
@@ -32,7 +32,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Set up ESPHome binary sensors based on a config entry."""
+    """Set up Rainbird switch entities."""
     data = hass.data.get(DOMAIN)[config_entry.entry_id]
 
     def _add_entities(future: asyncio.futures.Future):
@@ -63,11 +63,12 @@ def _get_entities(config_entry, data: RuntimeEntryData, hass: HomeAssistantType)
 class RainBirdSwitch(RainbirdEntity, SwitchEntity):
     """Representation of a Rain Bird switch."""
 
-    def __init__(self, hass, controller, device_info, data):
+    def __init__(self, rb: RainbirdController, device_info: dict, hass: HomeAssistantType,
+                 data: RuntimeEntryData = None):
         """Initialize a Rain Bird Switch Device."""
         self._zone = int(device_info.get(CONF_ZONE))
         self._duration = device_info.get(CONF_TRIGGER_TIME)
-        super(RainBirdSwitch, self).__init__(hass, controller,
+        super(RainBirdSwitch, self).__init__(hass, rb,
                                              "Zone {}".format(self._zone),
                                              "switch_%d" % self._zone,
                                              device_info, data, 'mdi:sprinkler-variant',

--- a/custom_components/rainbird/switch.py
+++ b/custom_components/rainbird/switch.py
@@ -9,7 +9,7 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CONF_SWITCHES,
     CONF_TRIGGER_TIME,
-    CONF_ZONE, CONF_HOST, )
+    CONF_ZONE, CONF_NAME, )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import HomeAssistantType
 from pyrainbird import RainbirdController
@@ -63,21 +63,16 @@ def _get_entities(config_entry, data: RuntimeEntryData, hass: HomeAssistantType)
 class RainBirdSwitch(RainbirdEntity, SwitchEntity):
     """Representation of a Rain Bird switch."""
 
-    def __init__(self, rb: RainbirdController, device_info: dict, hass: HomeAssistantType,
-                 data: RuntimeEntryData = None):
+    def __init__(self, hass, controller, device_info, data):
         """Initialize a Rain Bird Switch Device."""
         self._zone = int(device_info.get(CONF_ZONE))
         self._duration = device_info.get(CONF_TRIGGER_TIME)
-        super(RainBirdSwitch, self).__init__(hass, rb, device_info.get("id"),
-                                             device_info.get(CONF_FRIENDLY_NAME, "Rainbird {} #{}").format(
-                                                 device_info.get(CONF_HOST), self._zone), data, 'mdi:sprinkler-variant',
+        super(RainBirdSwitch, self).__init__(hass, controller,
+                                             "Zone {}".format(self._zone),
+                                             "switch_%d" % self._zone,
+                                             device_info, data, 'mdi:sprinkler-variant',
                                              attributes={"duration": self._duration, "zone": self._zone})
         self._state = None
-
-    @property
-    def unique_id(self):
-        """Return Unique ID string."""
-        return "%s_switch_%d" % (DOMAIN, self._zone)
 
     def turn_on(self, **kwargs):
         """Turn the switch on."""

--- a/custom_components/rainbird/translations/en.json
+++ b/custom_components/rainbird/translations/en.json
@@ -4,12 +4,15 @@
       "user": {
         "description": "Setup new Rainbird controller",
         "data": {
-          "host": "Host name of Rainbird controller",
+          "name": "Friendly name of this rainbird device",
+          "host": "Hostname or IP of Rainbird controller",
           "password": "Password for controller",
-          "number_of_stations": "Number of irrigation circuits (if 0 or missing, circuits will be automatically detected",
+          "number_of_stations": "Number of irrigation circuits (0 = auto)",
           "monitored_conditions": "Active sensors",
-          "trigger_time": "default irrigation time",
-          "scan_interval": "Sensor update period"
+          "trigger_time": "Default irrigation time",
+          "scan_interval": "Integration update interval",
+          "retry_count": "Number of retries",
+          "retry_delay": "Delay in seconds between each retry"
         }
       }
     },
@@ -23,13 +26,16 @@
   "options": {
     "step": {
       "init": {
-        "description": "Setup Rainbird controller at {host}",
+        "description": "Setup {name}",
         "data": {
+          "host": "Hostname or IP of Rainbird controller",
           "password": "Password for controller",
-          "number_of_stations": "Number of irrigation circuits (if 0, circuits will be automatically detected",
+          "number_of_stations": "Number of irrigation circuits (0 = auto)",
           "monitored_conditions": "Active sensors",
-          "trigger_time": "default irrigation time",
-          "scan_interval": "Sensor update period"
+          "trigger_time": "Default irrigation time",
+          "scan_interval": "Integration update interval",
+          "retry_count": "Number of retries",
+          "retry_delay": "Delay in seconds between each retry"
         }
       }
     }

--- a/hacs.json
+++ b/hacs.json
@@ -11,7 +11,7 @@
   ],
   "country": "CZ",
   "render_readme": true,
-  "iot_class": "Cloud Polling",
+  "iot_class": "Local Polling",
   "icon": "https://brands.home-assistant.io/_/rainbird/icon.png",
   "logo": "https://brands.home-assistant.io/_/rainbird/logo.png"
 }


### PR DESCRIPTION
Hi there!

Happy to have seen you started a migration of the built in Rainbird integration into the config flow, etc. I had that on my todo list mid August, and just got around to it today. Instead, I got to focus on what I wanted to do more - add features.

There's a lot of code change here - tried to clean some things up to follow HA patterns better (serial, rather than hostname, for device_id). 

I also added the ability to get and set the rain-delay feature via a number slider. 

I'm hoping to add the seasonal adjust percentage, and device availability, next (mark unavailable if update fails). The iPhone app shows a "next watering date", but this isn't exposed in the python API currently - that would be my ultimate goal.

![Screen Shot 2021-09-25 at 2 44 33 PM](https://user-images.githubusercontent.com/242763/134786712-b25b59fe-816b-447a-b926-b43c8c125872.png)

